### PR TITLE
✨ feat: 월별&일별 사용 대장

### DIFF
--- a/src/main/java/fast/mini/be/domain/admin/AdminController.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminController.java
@@ -18,29 +18,26 @@ public class AdminController {
     private final AdminService adminService;
 
     @PostMapping("/order/update")
-    public ResponseEntity<?> orderUpdate(@Valid @RequestBody AdminRequest.OrderUpdateDTO orderUpdateDTO){
+    public ResponseEntity<?> orderUpdate(@Valid @RequestBody AdminRequest.OrderUpdateDTO orderUpdateDTO) {
         adminService.orderUpdate(orderUpdateDTO);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @GetMapping("/order/list/{status}")
     public ResponseEntity<?> orderListByStatus(@PathVariable("status") String status, Pageable pageable) {
-        if(!("wait".equals(status)) && !("complete".equals(status))){
-            throw new Exception400("url","잘못된 입력입니다.");
+        if (!("wait".equals(status)) && !("complete".equals(status))) {
+            throw new Exception400("url", "잘못된 입력입니다.");
         }
 
         Page<AdminResponse.OrderByStatusDTO> orderListByStatusDTO = adminService.orderListByStatus(status, pageable);
-        return new ResponseEntity<>(orderListByStatusDTO,HttpStatus.OK);
+        return new ResponseEntity<>(orderListByStatusDTO, HttpStatus.OK);
     }
 
     @GetMapping("/order/list/monthly/{orderType}")
-    public ResponseEntity<?> monthlyUserTotal(@PathVariable("orderType") String orderType, @RequestParam(value = "year")int year) {
-        if(!("duty".equals(orderType)) && !("annual".equals(orderType))){
-            throw new Exception400("url","잘못된 입력입니다.");
-        }
-
-        List<AdminResponse.MonthlyUserTotalDTO> monthlyUserTotal = adminService.monthlyUserTotal(new AdminRequest.MonthlyUserTotalDTO(orderType, year));
-        return new ResponseEntity<>(monthlyUserTotal,HttpStatus.OK);
+    public ResponseEntity<?> monthlyUserTotal(@PathVariable("orderType") String orderType, @RequestParam(value = "year") int year) {
+        AdminRequest.MonthlyUserTotalDTO requestDTO = new AdminRequest.MonthlyUserTotalDTO(orderType, year);
+        List<AdminResponse.MonthlyUserTotalDTO> monthlyUserTotal = adminService.monthlyUserTotal(requestDTO);
+        return new ResponseEntity<>(monthlyUserTotal, HttpStatus.OK);
     }
 
     @GetMapping("/order/list/{orderType}")

--- a/src/main/java/fast/mini/be/domain/admin/AdminController.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -30,5 +31,15 @@ public class AdminController {
 
         Page<AdminResponse.OrderByStatusDTO> orderListByStatusDTO = adminService.orderListByStatus(status, pageable);
         return new ResponseEntity<>(orderListByStatusDTO,HttpStatus.OK);
+    }
+
+    @GetMapping("/order/list/monthly/{orderType}")
+    public ResponseEntity<?> monthlyUserTotal(@PathVariable("orderType") String orderType, @RequestParam(value = "year")int year) {
+        if(!("duty".equals(orderType)) && !("annual".equals(orderType))){
+            throw new Exception400("url","잘못된 입력입니다.");
+        }
+
+        List<AdminResponse.MonthlyUserTotalDTO> monthlyUserTotal = adminService.monthlyUserTotal(new AdminRequest.MonthlyUserTotalDTO(orderType, year));
+        return new ResponseEntity<>(monthlyUserTotal,HttpStatus.OK);
     }
 }

--- a/src/main/java/fast/mini/be/domain/admin/AdminController.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminController.java
@@ -17,7 +17,7 @@ public class AdminController {
     private final AdminService adminService;
 
     @PostMapping("/order/update")
-    public ResponseEntity<?> orderUpdate(@Valid @RequestBody AdminRequest.orderUpdateDTO orderUpdateDTO){
+    public ResponseEntity<?> orderUpdate(@Valid @RequestBody AdminRequest.OrderUpdateDTO orderUpdateDTO){
         adminService.orderUpdate(orderUpdateDTO);
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/src/main/java/fast/mini/be/domain/admin/AdminController.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminController.java
@@ -42,4 +42,15 @@ public class AdminController {
         List<AdminResponse.MonthlyUserTotalDTO> monthlyUserTotal = adminService.monthlyUserTotal(new AdminRequest.MonthlyUserTotalDTO(orderType, year));
         return new ResponseEntity<>(monthlyUserTotal,HttpStatus.OK);
     }
+
+    @GetMapping("/order/list/{orderType}")
+    public ResponseEntity<?> dailyOrderList(
+            @PathVariable("orderType") String orderType,
+            @RequestParam(value = "year") int year,
+            @RequestParam(value = "month") int month
+    ) {
+        AdminRequest.DailyOrderListDTO requestDTO = new AdminRequest.DailyOrderListDTO(orderType, year, month);
+        List<AdminResponse.DailyOrderDTO> dailyOrderDTOList = adminService.dailyOrderList(requestDTO);
+        return new ResponseEntity<>(dailyOrderDTOList, HttpStatus.OK);
+    }
 }

--- a/src/main/java/fast/mini/be/domain/admin/AdminController.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminController.java
@@ -10,8 +10,6 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
-import static fast.mini.be.domain.admin.AdminRequest.*;
-
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/admin")
@@ -19,7 +17,7 @@ public class AdminController {
     private final AdminService adminService;
 
     @PostMapping("/order/update")
-    public ResponseEntity<?> orderUpdate(@Valid @RequestBody orderUpdateDTO orderUpdateDTO){
+    public ResponseEntity<?> orderUpdate(@Valid @RequestBody AdminRequest.orderUpdateDTO orderUpdateDTO){
         adminService.orderUpdate(orderUpdateDTO);
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/src/main/java/fast/mini/be/domain/admin/AdminController.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminController.java
@@ -22,8 +22,8 @@ public class AdminController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @PostMapping("/order/list/{status}")
-    public ResponseEntity<?> orderUpdate(@PathVariable("status") String status, Pageable pageable) {
+    @GetMapping("/order/list/{status}")
+    public ResponseEntity<?> orderListByStatus(@PathVariable("status") String status, Pageable pageable) {
         if(!("wait".equals(status)) && !("complete".equals(status))){
             throw new Exception400("url","잘못된 입력입니다.");
         }

--- a/src/main/java/fast/mini/be/domain/admin/AdminRequest.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminRequest.java
@@ -35,6 +35,10 @@ public class AdminRequest {
         int year;
 
         public MonthlyUserTotalDTO(String orderType, int year) {
+            if (!("duty".equals(orderType)) && !("annual".equals(orderType))) {
+                throw new Exception400("url", "잘못된 입력입니다.");
+            }
+
             this.orderType = OrderType.valueOf(orderType.toUpperCase());
             this.year = year;
         }

--- a/src/main/java/fast/mini/be/domain/admin/AdminRequest.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminRequest.java
@@ -14,6 +14,7 @@ public class AdminRequest {
     public static class OrderUpdateDTO {
         @NotEmpty
         Long id;
+
         @NotEmpty
         OrderStatus status;
 
@@ -28,6 +29,7 @@ public class AdminRequest {
     public static class MonthlyUserTotalDTO{
         @NotEmpty
         OrderType orderType;
+
         @NotEmpty
         int year;
 

--- a/src/main/java/fast/mini/be/domain/admin/AdminRequest.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminRequest.java
@@ -2,6 +2,7 @@ package fast.mini.be.domain.admin;
 
 import fast.mini.be.domain.order.OrderStatus;
 import fast.mini.be.domain.order.OrderType;
+import fast.mini.be.global.erros.exception.Exception400;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -26,7 +27,7 @@ public class AdminRequest {
 
     @Getter
     @Setter
-    public static class MonthlyUserTotalDTO{
+    public static class MonthlyUserTotalDTO {
         @NotEmpty
         OrderType orderType;
 
@@ -52,6 +53,10 @@ public class AdminRequest {
         int month;
 
         public DailyOrderListDTO(String orderType, int year, int month) {
+            if (!("duty".equals(orderType)) && !("annual".equals(orderType))) {
+                throw new Exception400("url", "잘못된 입력입니다.");
+            }
+
             this.orderType = OrderType.valueOf(orderType.toUpperCase());
             this.year = year;
             this.month = month;

--- a/src/main/java/fast/mini/be/domain/admin/AdminRequest.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminRequest.java
@@ -11,13 +11,13 @@ public class AdminRequest {
 
     @Getter
     @Setter
-    public static class orderUpdateDTO{
+    public static class OrderUpdateDTO {
         @NotEmpty
         Long id;
         @NotEmpty
         OrderStatus status;
 
-        public orderUpdateDTO(Long id, String status) {
+        public OrderUpdateDTO(Long id, String status) {
             this.id = id;
             this.status = OrderStatus.findByLabel(status);
         }

--- a/src/main/java/fast/mini/be/domain/admin/AdminRequest.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminRequest.java
@@ -1,6 +1,7 @@
 package fast.mini.be.domain.admin;
 
 import fast.mini.be.domain.order.OrderStatus;
+import fast.mini.be.domain.order.OrderType;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -19,6 +20,20 @@ public class AdminRequest {
         public orderUpdateDTO(Long id, String status) {
             this.id = id;
             this.status = OrderStatus.findByLabel(status);
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class MonthlyUserTotalDTO{
+        @NotEmpty
+        OrderType orderType;
+        @NotEmpty
+        int year;
+
+        public MonthlyUserTotalDTO(String orderType, int year) {
+            this.orderType = OrderType.valueOf(orderType.toUpperCase());
+            this.year = year;
         }
     }
 }

--- a/src/main/java/fast/mini/be/domain/admin/AdminRequest.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminRequest.java
@@ -38,4 +38,23 @@ public class AdminRequest {
             this.year = year;
         }
     }
+
+    @Getter
+    @Setter
+    public static class DailyOrderListDTO {
+        @NotEmpty
+        OrderType orderType;
+
+        @NotEmpty
+        int year;
+
+        @NotEmpty
+        int month;
+
+        public DailyOrderListDTO(String orderType, int year, int month) {
+            this.orderType = OrderType.valueOf(orderType.toUpperCase());
+            this.year = year;
+            this.month = month;
+        }
+    }
 }

--- a/src/main/java/fast/mini/be/domain/admin/AdminResponse.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminResponse.java
@@ -3,15 +3,21 @@ package fast.mini.be.domain.admin;
 import fast.mini.be.domain.approveDate.ApproveDate;
 import fast.mini.be.domain.order.Order;
 import fast.mini.be.domain.user.User;
+import fast.mini.be.global.erros.exception.Exception500;
+import fast.mini.be.global.utils.AES256;
 import fast.mini.be.global.utils.DateUtils;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 
 import java.time.Month;
 import java.util.List;
 
 public class AdminResponse {
+    private static final AES256 AES256 = new AES256();
+
     @Getter
     @Setter
     public static class OrderByStatusDTO {
@@ -28,7 +34,11 @@ public class AdminResponse {
 
         private OrderByStatusDTO(Order order) {
             this.id = order.getId();
-            this.empName = order.getUser().getEmpName();
+            try {
+                this.empName = AES256.decrypt(order.getUser().getEmpName());
+            } catch (Exception e) {
+                throw new Exception500("서버 오류!");
+            }
             this.createdAt = DateUtils.toStringFormat(order.getCreatedAt());
             this.orderType = order.getOrderType().getLabel();
             this.status = order.getStatus().getLabel();
@@ -112,7 +122,11 @@ public class AdminResponse {
 
         public MonthlyUserTotalDTO(User user,MonthCountDTO monthCountDTO) {
             this.id = user.getId();
-            this.empName = user.getEmpName();
+            try {
+                this.empName = AES256.decrypt(user.getEmpName());
+            } catch (Exception e) {
+                throw new Exception500("서버 오류!");
+            }
             this.empNo = user.getEmpNo();
             this.month =monthCountDTO;
             this.total = monthCountDTO.getTotalCount();

--- a/src/main/java/fast/mini/be/domain/admin/AdminResponse.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminResponse.java
@@ -1,10 +1,15 @@
 package fast.mini.be.domain.admin;
 
+import fast.mini.be.domain.approveDate.ApproveDate;
 import fast.mini.be.domain.order.Order;
+import fast.mini.be.domain.user.User;
 import fast.mini.be.global.utils.DateUtils;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.data.domain.Page;
+
+import java.time.Month;
+import java.util.List;
 
 public class AdminResponse {
     @Getter
@@ -36,6 +41,81 @@ public class AdminResponse {
 
         public static Page<OrderByStatusDTO> fromEntityList(Page<Order> orderList) {
             return orderList.map(OrderByStatusDTO::new);
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class MonthCountDTO{
+        Long jan;
+        Long feb;
+        Long mar;
+        Long apr;
+        Long may;
+        Long jun;
+        Long jul;
+        Long aug;
+        Long sept;
+        Long oct;
+        Long nov;
+        Long dec;
+
+        public MonthCountDTO() {
+            this.jan = 0L;
+            this.feb = 0L;
+            this.mar = 0L;
+            this.apr = 0L;
+            this.may = 0L;
+            this.jun = 0L;
+            this.jul = 0L;
+            this.aug = 0L;
+            this.sept = 0L;
+            this.oct = 0L;
+            this.nov = 0L;
+            this.dec = 0L;
+        }
+
+        public void count(List<ApproveDate> approveDateList) {
+            this.jan = countForMonth(approveDateList, Month.JANUARY);
+            this.feb = countForMonth(approveDateList, Month.FEBRUARY);
+            this.mar = countForMonth(approveDateList, Month.MARCH);
+            this.apr = countForMonth(approveDateList, Month.APRIL);
+            this.may = countForMonth(approveDateList, Month.MAY);
+            this.jun = countForMonth(approveDateList, Month.JUNE);
+            this.jul = countForMonth(approveDateList, Month.JULY);
+            this.aug = countForMonth(approveDateList, Month.AUGUST);
+            this.sept = countForMonth(approveDateList, Month.SEPTEMBER);
+            this.oct = countForMonth(approveDateList, Month.OCTOBER);
+            this.nov = countForMonth(approveDateList, Month.NOVEMBER);
+            this.dec = countForMonth(approveDateList, Month.DECEMBER);
+        }
+
+        private long countForMonth(List<ApproveDate> approveDateList, Month month) {
+            return approveDateList.stream()
+                    .filter(approveDate -> approveDate.getDate().toLocalDate().getMonth() == month)
+                    .count();
+        }
+
+        public Long getTotalCount() {
+            return jan + feb + mar + apr + may + jun + jul + aug + sept + oct + nov + dec;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class MonthlyUserTotalDTO {
+        Long id;
+        String empName;
+        String empNo;
+        MonthCountDTO month;
+        Long total;
+
+        public MonthlyUserTotalDTO(User user,MonthCountDTO monthCountDTO) {
+            this.id = user.getId();
+            this.empName = user.getEmpName();
+            this.empNo = user.getEmpNo();
+            this.month =monthCountDTO;
+            this.total = monthCountDTO.getTotalCount();
         }
     }
 }

--- a/src/main/java/fast/mini/be/domain/admin/AdminResponse.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminResponse.java
@@ -7,9 +7,6 @@ import fast.mini.be.global.erros.exception.Exception500;
 import fast.mini.be.global.utils.AES256;
 import fast.mini.be.global.utils.DateUtils;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 
 import java.time.Month;
@@ -19,7 +16,6 @@ public class AdminResponse {
     private static final AES256 AES256 = new AES256();
 
     @Getter
-    @Setter
     public static class OrderByStatusDTO {
         Long id;
         String empName;
@@ -55,7 +51,6 @@ public class AdminResponse {
     }
 
     @Getter
-    @Setter
     public static class MonthCountDTO{
         Long jan;
         Long feb;
@@ -112,7 +107,6 @@ public class AdminResponse {
     }
 
     @Getter
-    @Setter
     public static class MonthlyUserTotalDTO {
         Long id;
         String empName;

--- a/src/main/java/fast/mini/be/domain/admin/AdminResponse.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminResponse.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page;
 
 import java.time.Month;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class AdminResponse {
     private static final AES256 AES256 = new AES256();
@@ -124,6 +125,29 @@ public class AdminResponse {
             this.empNo = user.getEmpNo();
             this.month =monthCountDTO;
             this.total = monthCountDTO.getTotalCount();
+        }
+    }
+
+    @Getter
+    public static class DailyOrderDTO {
+        String empName;
+        String empNo;
+        String orderType;
+        String date;
+
+        private DailyOrderDTO(ApproveDate approveDate) {
+            try {
+                this.empName = AES256.decrypt(approveDate.getUser().getEmpName());
+            } catch (Exception e) {
+                throw new Exception500("서버 오류!");
+            }
+            this.empNo = approveDate.getUser().getEmpNo();
+            this.orderType = approveDate.getOrder().getOrderType().getLabel();
+            this.date = DateUtils.toStringFormat(approveDate.getDate());
+        }
+
+        public static List<DailyOrderDTO> fromEntityList(List<ApproveDate> approveDateList) {
+            return approveDateList.stream().map(DailyOrderDTO::new).collect(Collectors.toList());
         }
     }
 }

--- a/src/main/java/fast/mini/be/domain/admin/AdminService.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminService.java
@@ -80,4 +80,14 @@ public class AdminService {
 
         return monthlyUserTotalDTOList;
     }
+
+    public List<AdminResponse.DailyOrderDTO> dailyOrderList(AdminRequest.DailyOrderListDTO dailyOrderListDTO){
+        List<ApproveDate> approveDateList = approveDateRepository
+                .findAllByOrderTypeInYearMonth(
+                        dailyOrderListDTO.getOrderType(), dailyOrderListDTO.getYear(), dailyOrderListDTO.getMonth()
+                )
+                .orElseThrow(() -> new Exception404("해당 데이터가 존재하지 않습니다."));
+
+        return AdminResponse.DailyOrderDTO.fromEntityList(approveDateList);
+    }
 }

--- a/src/main/java/fast/mini/be/domain/admin/AdminService.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminService.java
@@ -1,6 +1,5 @@
 package fast.mini.be.domain.admin;
 
-import fast.mini.be.domain.admin.AdminResponse.OrderByStatusDTO;
 import fast.mini.be.domain.approveDate.ApproveDate;
 import fast.mini.be.domain.approveDate.ApproveDateRepository;
 import fast.mini.be.domain.order.Order;
@@ -20,8 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static fast.mini.be.domain.admin.AdminRequest.orderUpdateDTO;
-
 @RequiredArgsConstructor
 @Service
 public class AdminService {
@@ -29,7 +26,7 @@ public class AdminService {
     private final ApproveDateRepository approveDateRepository;
     private final UserRepository userRepository;
 
-    public void orderUpdate(orderUpdateDTO orderUpdateDTO) {
+    public void orderUpdate(AdminRequest.orderUpdateDTO orderUpdateDTO) {
         Order orderPS = orderRepository.findById(orderUpdateDTO.getId())
                 .orElseThrow(() -> new Exception404("결재 요청을 찾을 수 없습니다."));
 
@@ -50,7 +47,7 @@ public class AdminService {
         }
     }
   
-    public Page<OrderByStatusDTO> orderListByStatus(String status, Pageable pageable){
+    public Page<AdminResponse.OrderByStatusDTO> orderListByStatus(String status, Pageable pageable){
         Page<Order> orderList;
         if(OrderStatus.WAIT.name().equals(status.toUpperCase())){
             orderList= orderRepository.findAllByStatus(OrderStatus.WAIT, pageable);
@@ -58,7 +55,7 @@ public class AdminService {
             orderList= orderRepository.findAllByStatusNot(OrderStatus.WAIT, pageable);
         }
 
-        Page<OrderByStatusDTO> orderDTOList = OrderByStatusDTO.fromEntityList(orderList);
+        Page<AdminResponse.OrderByStatusDTO> orderDTOList = AdminResponse.OrderByStatusDTO.fromEntityList(orderList);
         return orderDTOList;
     }
 

--- a/src/main/java/fast/mini/be/domain/admin/AdminService.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminService.java
@@ -55,8 +55,7 @@ public class AdminService {
             orderList= orderRepository.findAllByStatusNot(OrderStatus.WAIT, pageable);
         }
 
-        Page<AdminResponse.OrderByStatusDTO> orderDTOList = AdminResponse.OrderByStatusDTO.fromEntityList(orderList);
-        return orderDTOList;
+        return AdminResponse.OrderByStatusDTO.fromEntityList(orderList);
     }
 
     public List<AdminResponse.MonthlyUserTotalDTO> monthlyUserTotal(AdminRequest.MonthlyUserTotalDTO monthlyUserTotalDTO){
@@ -70,8 +69,9 @@ public class AdminService {
             AdminResponse.MonthCountDTO monthCountDTO = new AdminResponse.MonthCountDTO();
 
             // 해당 사원이 승인된 요청을 가지는지 찾고 월별 카운트를 갱신한다
-            Optional<List<ApproveDate>> approveDateList = approveDateRepository.findApproveDatesForUserByOrderTypeInYear(
-                            user.getId(), monthlyUserTotalDTO.getOrderType(), monthlyUserTotalDTO.getYear());
+            Optional<List<ApproveDate>> approveDateList = approveDateRepository.findAllByUserAndOrderTypeInYear(
+                            user.getId(), monthlyUserTotalDTO.getOrderType(), monthlyUserTotalDTO.getYear()
+            );
             approveDateList.ifPresent(monthCountDTO::count);
 
             // 해당 사원의 사용 대장을 추가한다

--- a/src/main/java/fast/mini/be/domain/admin/AdminService.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminService.java
@@ -26,7 +26,7 @@ public class AdminService {
     private final ApproveDateRepository approveDateRepository;
     private final UserRepository userRepository;
 
-    public void orderUpdate(AdminRequest.orderUpdateDTO orderUpdateDTO) {
+    public void orderUpdate(AdminRequest.OrderUpdateDTO orderUpdateDTO) {
         Order orderPS = orderRepository.findById(orderUpdateDTO.getId())
                 .orElseThrow(() -> new Exception404("결재 요청을 찾을 수 없습니다."));
 

--- a/src/main/java/fast/mini/be/domain/approveDate/ApproveDateRepository.java
+++ b/src/main/java/fast/mini/be/domain/approveDate/ApproveDateRepository.java
@@ -11,4 +11,8 @@ public interface ApproveDateRepository extends JpaRepository<ApproveDate, Long> 
     @Query("SELECT a FROM ApproveDate a " +
             "WHERE a.user.id = :userId AND a.order.orderType = :orderType AND YEAR(a.date) = :year")
     Optional<List<ApproveDate>> findAllByUserAndOrderTypeInYear(Long userId, OrderType orderType, int year);
+
+    @Query("SELECT a FROM ApproveDate a " +
+            "WHERE a.order.orderType = :orderType AND YEAR(a.date) = :year AND MONTH(a.date) = :month")
+    Optional<List<ApproveDate>> findAllByOrderTypeInYearMonth(OrderType orderType, int year, int month);
 }

--- a/src/main/java/fast/mini/be/domain/approveDate/ApproveDateRepository.java
+++ b/src/main/java/fast/mini/be/domain/approveDate/ApproveDateRepository.java
@@ -1,6 +1,14 @@
 package fast.mini.be.domain.approveDate;
 
+import fast.mini.be.domain.order.OrderType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface ApproveDateRepository extends JpaRepository<ApproveDate, Long> {
+    @Query("SELECT a FROM ApproveDate a " +
+            "WHERE a.user.id = :userId AND a.order.orderType = :orderType AND FUNCTION('YEAR', a.date) = :year")
+    Optional<List<ApproveDate>> findApproveDatesForUserByOrderTypeInYear(Long userId, OrderType orderType, int year);
 }

--- a/src/main/java/fast/mini/be/domain/approveDate/ApproveDateRepository.java
+++ b/src/main/java/fast/mini/be/domain/approveDate/ApproveDateRepository.java
@@ -10,5 +10,5 @@ import java.util.Optional;
 public interface ApproveDateRepository extends JpaRepository<ApproveDate, Long> {
     @Query("SELECT a FROM ApproveDate a " +
             "WHERE a.user.id = :userId AND a.order.orderType = :orderType AND FUNCTION('YEAR', a.date) = :year")
-    Optional<List<ApproveDate>> findApproveDatesForUserByOrderTypeInYear(Long userId, OrderType orderType, int year);
+    Optional<List<ApproveDate>> findAllByUserAndOrderTypeInYear(Long userId, OrderType orderType, int year);
 }

--- a/src/main/java/fast/mini/be/domain/approveDate/ApproveDateRepository.java
+++ b/src/main/java/fast/mini/be/domain/approveDate/ApproveDateRepository.java
@@ -9,6 +9,6 @@ import java.util.Optional;
 
 public interface ApproveDateRepository extends JpaRepository<ApproveDate, Long> {
     @Query("SELECT a FROM ApproveDate a " +
-            "WHERE a.user.id = :userId AND a.order.orderType = :orderType AND FUNCTION('YEAR', a.date) = :year")
+            "WHERE a.user.id = :userId AND a.order.orderType = :orderType AND YEAR(a.date) = :year")
     Optional<List<ApproveDate>> findAllByUserAndOrderTypeInYear(Long userId, OrderType orderType, int year);
 }

--- a/src/main/java/fast/mini/be/domain/user/repository/UserRepository.java
+++ b/src/main/java/fast/mini/be/domain/user/repository/UserRepository.java
@@ -1,9 +1,11 @@
 package fast.mini.be.domain.user.repository;
 
+import fast.mini.be.domain.user.Role;
 import fast.mini.be.domain.user.User;
-import java.util.Optional;
-import javax.swing.text.html.Option;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
@@ -13,5 +15,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByRefreshToken(String refreshToken);
 
-
+    Optional<List<User>> findAllByRole(Role role);
 }

--- a/src/test/java/fast/mini/be/domain/admin/AdminServiceTest.java
+++ b/src/test/java/fast/mini/be/domain/admin/AdminServiceTest.java
@@ -231,4 +231,22 @@ class AdminServiceTest {
         assertEquals(userTotalDTO.getMonth().getDec(),0L,"12월 당직 사용 내역");
         assertEquals(userTotalDTO.getTotal(),2L,"total 당직 사용 내역");
     }
+
+    @Test
+    public void ok_dailyOrderList_duty() {
+        // given
+        String orderType = "duty";
+        int year = 2023;
+        int month = 8;
+        AdminRequest.DailyOrderListDTO dailyOrderListDTO = new AdminRequest.DailyOrderListDTO(orderType, year, month);
+
+        // when
+        List<AdminResponse.DailyOrderDTO> dailyOrderDTOList = adminService.dailyOrderList(dailyOrderListDTO);
+
+        // then
+        assertEquals(dailyOrderDTOList.size(), 2, "년월이 일치하는 당직 승인 개수");
+        dailyOrderDTOList.forEach(
+                o -> assertTrue(o.getDate().matches("^2023-08-(0[1-9]|[1-2][0-9]|3[0-1])$"))
+        );
+    }
 }

--- a/src/test/java/fast/mini/be/domain/admin/AdminServiceTest.java
+++ b/src/test/java/fast/mini/be/domain/admin/AdminServiceTest.java
@@ -100,7 +100,7 @@ class AdminServiceTest {
     @Test
     public void ok_orderListByStatus_WAIT_first_page() {
         // given
-        Pageable pageable = (Pageable) PageRequest.of(0,4);
+        Pageable pageable = (Pageable) PageRequest.of(0, 4);
         String status = "wait";
 
         // when
@@ -121,7 +121,7 @@ class AdminServiceTest {
     @Test
     public void ok_orderListByStatus_WAIT_next_page() {
         // given
-        Pageable pageable = (Pageable) PageRequest.of(1,4);
+        Pageable pageable = (Pageable) PageRequest.of(1, 4);
         String status = "wait";
 
         // when
@@ -141,7 +141,7 @@ class AdminServiceTest {
     @Test
     public void ok_orderListByStatus_NOT_WAIT_first_page() {
         // given
-        Pageable pageable = (Pageable) PageRequest.of(0,4);
+        Pageable pageable = (Pageable) PageRequest.of(0, 4);
         String status = "complete";
 
         // when
@@ -161,7 +161,7 @@ class AdminServiceTest {
     @Test
     public void ok_orderListByStatus_NOT_WAIT_next_page() {
         // given
-        Pageable pageable = (Pageable) PageRequest.of(1,4);
+        Pageable pageable = (Pageable) PageRequest.of(1, 4);
         String status = "complete";
 
         // when
@@ -179,8 +179,8 @@ class AdminServiceTest {
     }
 
     @Test
-    public void ok_monthlyUserTotal_annual(){
-    	// given
+    public void ok_monthlyUserTotal_annual() {
+        // given
         String orderType = "annual";
         int year = 2023;
         AdminRequest.MonthlyUserTotalDTO monthlyUserTotalDTO = new AdminRequest.MonthlyUserTotalDTO(orderType, year);
@@ -190,23 +190,23 @@ class AdminServiceTest {
 
         // then
         AdminResponse.MonthlyUserTotalDTO userTotalDTO = monthlyUserTotalDTOList.get(1);// id=2인 유저
-        assertEquals(userTotalDTO.getMonth().getJan(),6L,"1월 연차 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getFeb(),0L,"2월 연차 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getMar(),0L,"3월 연차 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getApr(),0L,"4월 연차 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getMay(),5L,"5월 연차 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getJun(),0L,"6월 연차 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getJul(),0L,"7월 연차 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getAug(),0L,"8월 연차 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getSept(),0L,"9월 연차 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getOct(),0L,"10월 연차 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getNov(),4L,"11월 연차 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getDec(),0L,"12월 연차 사용 내역");
-        assertEquals(userTotalDTO.getTotal(),15L,"total 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getJan(), 6L, "1월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getFeb(), 0L, "2월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getMar(), 0L, "3월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getApr(), 0L, "4월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getMay(), 5L, "5월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getJun(), 0L, "6월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getJul(), 0L, "7월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getAug(), 0L, "8월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getSept(), 0L, "9월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getOct(), 0L, "10월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getNov(), 4L, "11월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getDec(), 0L, "12월 연차 사용 내역");
+        assertEquals(userTotalDTO.getTotal(), 15L, "total 연차 사용 내역");
     }
 
     @Test
-    public void ok_monthlyUserTotal_duty(){
+    public void ok_monthlyUserTotal_duty() {
         // given
         String orderType = "duty";
         int year = 2023;
@@ -217,19 +217,19 @@ class AdminServiceTest {
 
         // then
         AdminResponse.MonthlyUserTotalDTO userTotalDTO = monthlyUserTotalDTOList.get(1);// id=2인 유저
-        assertEquals(userTotalDTO.getMonth().getJan(),1L,"1월 당직 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getFeb(),0L,"2월 당직 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getMar(),0L,"3월 당직 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getApr(),0L,"4월 당직 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getMay(),0L,"5월 당직 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getJun(),0L,"6월 당직 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getJul(),0L,"7월 당직 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getAug(),1L,"8월 당직 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getSept(),0L,"9월 당직 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getOct(),0L,"10월 당직 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getNov(),0L,"11월 당직 사용 내역");
-        assertEquals(userTotalDTO.getMonth().getDec(),0L,"12월 당직 사용 내역");
-        assertEquals(userTotalDTO.getTotal(),2L,"total 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getJan(), 1L, "1월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getFeb(), 0L, "2월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getMar(), 0L, "3월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getApr(), 0L, "4월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getMay(), 0L, "5월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getJun(), 0L, "6월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getJul(), 0L, "7월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getAug(), 1L, "8월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getSept(), 0L, "9월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getOct(), 0L, "10월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getNov(), 0L, "11월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getDec(), 0L, "12월 당직 사용 내역");
+        assertEquals(userTotalDTO.getTotal(), 2L, "total 당직 사용 내역");
     }
 
     @Test

--- a/src/test/java/fast/mini/be/domain/admin/AdminServiceTest.java
+++ b/src/test/java/fast/mini/be/domain/admin/AdminServiceTest.java
@@ -39,7 +39,7 @@ class AdminServiceTest {
         String status = "반려";
 
         // when
-        adminService.orderUpdate(new AdminRequest.orderUpdateDTO(id, status));
+        adminService.orderUpdate(new AdminRequest.OrderUpdateDTO(id, status));
 
         // then
         Order order = orderRepository.findById(id).get();
@@ -53,7 +53,7 @@ class AdminServiceTest {
         String status = "승인";
 
         // when
-        adminService.orderUpdate(new AdminRequest.orderUpdateDTO(id, status));
+        adminService.orderUpdate(new AdminRequest.OrderUpdateDTO(id, status));
 
         // then
         Order order = orderRepository.findById(id).get();
@@ -80,7 +80,7 @@ class AdminServiceTest {
         // when
         // then
         assertThrows(Exception404.class, () -> {
-            adminService.orderUpdate(new AdminRequest.orderUpdateDTO(id, status));
+            adminService.orderUpdate(new AdminRequest.OrderUpdateDTO(id, status));
         });
     }
 
@@ -93,7 +93,7 @@ class AdminServiceTest {
         // when
         // then
         assertThrows(Exception400.class, () -> {
-            adminService.orderUpdate(new AdminRequest.orderUpdateDTO(id, status));
+            adminService.orderUpdate(new AdminRequest.OrderUpdateDTO(id, status));
         });
     }
 

--- a/src/test/java/fast/mini/be/domain/admin/AdminServiceTest.java
+++ b/src/test/java/fast/mini/be/domain/admin/AdminServiceTest.java
@@ -177,4 +177,58 @@ class AdminServiceTest {
         assertNotEquals(content.get(2).getStatus(), OrderStatus.WAIT.getLabel(), "요청 상태는 WAIT가 아니며 label(한글)로 반환 한다");
         assertNotEquals(content.get(3).getStatus(), OrderStatus.WAIT.getLabel(), "요청 상태는 WAIT가 아니며 label(한글)로 반환 한다");
     }
+
+    @Test
+    public void ok_monthlyUserTotal_annual(){
+    	// given
+        String orderType = "annual";
+        int year = 2023;
+        AdminRequest.MonthlyUserTotalDTO monthlyUserTotalDTO = new AdminRequest.MonthlyUserTotalDTO(orderType, year);
+
+        // when
+        List<AdminResponse.MonthlyUserTotalDTO> monthlyUserTotalDTOList = adminService.monthlyUserTotal(monthlyUserTotalDTO);
+
+        // then
+        AdminResponse.MonthlyUserTotalDTO userTotalDTO = monthlyUserTotalDTOList.get(1);// id=2인 유저
+        assertEquals(userTotalDTO.getMonth().getJan(),6L,"1월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getFeb(),0L,"2월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getMar(),0L,"3월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getApr(),0L,"4월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getMay(),5L,"5월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getJun(),0L,"6월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getJul(),0L,"7월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getAug(),0L,"8월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getSept(),0L,"9월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getOct(),0L,"10월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getNov(),4L,"11월 연차 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getDec(),0L,"12월 연차 사용 내역");
+        assertEquals(userTotalDTO.getTotal(),15L,"total 연차 사용 내역");
+    }
+
+    @Test
+    public void ok_monthlyUserTotal_duty(){
+        // given
+        String orderType = "duty";
+        int year = 2023;
+        AdminRequest.MonthlyUserTotalDTO monthlyUserTotalDTO = new AdminRequest.MonthlyUserTotalDTO(orderType, year);
+
+        // when
+        List<AdminResponse.MonthlyUserTotalDTO> monthlyUserTotalDTOList = adminService.monthlyUserTotal(monthlyUserTotalDTO);
+
+        // then
+        AdminResponse.MonthlyUserTotalDTO userTotalDTO = monthlyUserTotalDTOList.get(1);// id=2인 유저
+        assertEquals(userTotalDTO.getMonth().getJan(),1L,"1월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getFeb(),0L,"2월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getMar(),0L,"3월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getApr(),0L,"4월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getMay(),0L,"5월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getJun(),0L,"6월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getJul(),0L,"7월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getAug(),1L,"8월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getSept(),0L,"9월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getOct(),0L,"10월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getNov(),0L,"11월 당직 사용 내역");
+        assertEquals(userTotalDTO.getMonth().getDec(),0L,"12월 당직 사용 내역");
+        assertEquals(userTotalDTO.getTotal(),2L,"total 당직 사용 내역");
+    }
 }


### PR DESCRIPTION
API URL
1. api/admin/order/list/monthly/{orderType}?year=
2. api/admin/order/list/{orderType}?year=&month=

### 구현 기능
1. 월별 사용 대장
- 모든 사용자에 대한 **승인된** 요청 횟수를 월별로 응답한다.
- 유저 별로 묶어서 월별 사용 횟수를 리스트로 응답한다.
- url의 orderType=duty/annual 에 따라 당직, 연차 승인 건만 응답한다.
- 입력 year과 일치하는 년도의 월별 사용 대장을 응답한다.

2. 일별 사용 대장
- 해당 년, 월에 해당하는 모든 **승인된** 날짜를 응답한다.
- url의 orderType=duty/annual 에 따라 당직, 연차 승인 건만 응답한다.

### 테스트
- [X] service
- [ ] controller 

### 비고
Controller 의 jwtToken 검사 및 Controller Test는 모든 기능의 Service 구현 완료 후 일괄 추가 예정
