### PR TITLE
✨feat: 사원 조회, 사원 사용 내역 조회 구현

### DIFF
--- a/src/main/java/fast/mini/be/BeApplication.java
+++ b/src/main/java/fast/mini/be/BeApplication.java
@@ -2,14 +2,16 @@ package fast.mini.be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
+@EnableAspectJAutoProxy
 @SpringBootApplication
 public class BeApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(BeApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(BeApplication.class, args);
+    }
 
 }

--- a/src/main/java/fast/mini/be/domain/admin/AdminController.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminController.java
@@ -18,13 +18,20 @@ public class AdminController {
     private final AdminService adminService;
 
     @PostMapping("/order/update")
-    public ResponseEntity<?> orderUpdate(@Valid @RequestBody AdminRequest.OrderUpdateDTO orderUpdateDTO) {
+    public ResponseEntity<?> orderUpdate(
+            @RequestHeader("Authorization") String token,
+            @Valid @RequestBody AdminRequest.OrderUpdateDTO orderUpdateDTO
+    ) {
         adminService.orderUpdate(orderUpdateDTO);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
     @GetMapping("/order/list/{status}")
-    public ResponseEntity<?> orderListByStatus(@PathVariable("status") String status, Pageable pageable) {
+    public ResponseEntity<?> orderListByStatus(
+            @RequestHeader("Authorization") String token,
+            @PathVariable("status") String status,
+            Pageable pageable
+    ) {
         if (!("wait".equals(status)) && !("complete".equals(status))) {
             throw new Exception400("url", "잘못된 입력입니다.");
         }
@@ -34,7 +41,11 @@ public class AdminController {
     }
 
     @GetMapping("/order/list/monthly/{orderType}")
-    public ResponseEntity<?> monthlyUserTotal(@PathVariable("orderType") String orderType, @RequestParam(value = "year") int year) {
+    public ResponseEntity<?> monthlyUserTotal(
+            @RequestHeader("Authorization") String token,
+            @PathVariable("orderType") String orderType,
+            @RequestParam(value = "year") int year
+    ) {
         AdminRequest.MonthlyUserTotalDTO requestDTO = new AdminRequest.MonthlyUserTotalDTO(orderType, year);
         List<AdminResponse.MonthlyUserTotalDTO> monthlyUserTotal = adminService.monthlyUserTotal(requestDTO);
         return new ResponseEntity<>(monthlyUserTotal, HttpStatus.OK);
@@ -42,6 +53,7 @@ public class AdminController {
 
     @GetMapping("/order/list/{orderType}")
     public ResponseEntity<?> dailyOrderList(
+            @RequestHeader("Authorization") String token,
             @PathVariable("orderType") String orderType,
             @RequestParam(value = "year") int year,
             @RequestParam(value = "month") int month
@@ -53,6 +65,7 @@ public class AdminController {
 
     @GetMapping("/user/search")
     public ResponseEntity<?> userSearch(
+            @RequestHeader("Authorization") String token,
             @RequestParam(value = "name", required = false) String name,
             @RequestParam(value = "empno", required = false) String empNo
     ) {
@@ -67,6 +80,7 @@ public class AdminController {
 
     @GetMapping("/order/list")
     public ResponseEntity<?> orderListByUserId(
+            @RequestHeader("Authorization") String token,
             @RequestParam(value = "user") int userId,
             Pageable pageable
     ) {

--- a/src/main/java/fast/mini/be/domain/admin/AdminController.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminController.java
@@ -50,4 +50,18 @@ public class AdminController {
         List<AdminResponse.DailyOrderDTO> dailyOrderDTOList = adminService.dailyOrderList(requestDTO);
         return new ResponseEntity<>(dailyOrderDTOList, HttpStatus.OK);
     }
+
+    @GetMapping("/user/search")
+    public ResponseEntity<?> userSearch(
+            @RequestParam(value = "name", required = false) String name,
+            @RequestParam(value = "empno", required = false) String empNo
+    ) {
+        if ((name != null && empNo != null) || (name == null && empNo == null)) {
+            throw new Exception400("url", "잘못된 입력입니다.");
+        }
+
+        AdminRequest.UserSearchDTO requestDTO = new AdminRequest.UserSearchDTO(name, empNo);
+        AdminResponse.UserSearchDTO userSearchDTO = adminService.userSearch(requestDTO);
+        return new ResponseEntity<>(userSearchDTO, HttpStatus.OK);
+    }
 }

--- a/src/main/java/fast/mini/be/domain/admin/AdminController.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminController.java
@@ -64,4 +64,13 @@ public class AdminController {
         AdminResponse.UserSearchDTO userSearchDTO = adminService.userSearch(requestDTO);
         return new ResponseEntity<>(userSearchDTO, HttpStatus.OK);
     }
+
+    @GetMapping("/order/list")
+    public ResponseEntity<?> orderListByUserId(
+            @RequestParam(value = "user") int userId,
+            Pageable pageable
+    ) {
+        Page<AdminResponse.OrderByUserIdDTO> orderListByUserIdDTO = adminService.orderListByUserId((long) userId, pageable);
+        return new ResponseEntity<>(orderListByUserIdDTO, HttpStatus.OK);
+    }
 }

--- a/src/main/java/fast/mini/be/domain/admin/AdminController.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminController.java
@@ -26,7 +26,7 @@ public class AdminController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @GetMapping("/order/list/{status}")
+    @GetMapping("/order/list/status/{status}")
     public ResponseEntity<?> orderListByStatus(
             @RequestHeader("Authorization") String token,
             @PathVariable("status") String status,
@@ -51,7 +51,7 @@ public class AdminController {
         return new ResponseEntity<>(monthlyUserTotal, HttpStatus.OK);
     }
 
-    @GetMapping("/order/list/{orderType}")
+    @GetMapping("/order/list/daily/{orderType}")
     public ResponseEntity<?> dailyOrderList(
             @RequestHeader("Authorization") String token,
             @PathVariable("orderType") String orderType,

--- a/src/main/java/fast/mini/be/domain/admin/AdminRequest.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminRequest.java
@@ -3,12 +3,15 @@ package fast.mini.be.domain.admin;
 import fast.mini.be.domain.order.OrderStatus;
 import fast.mini.be.domain.order.OrderType;
 import fast.mini.be.global.erros.exception.Exception400;
+import fast.mini.be.global.erros.exception.Exception500;
+import fast.mini.be.global.utils.AES256;
 import lombok.Getter;
 import lombok.Setter;
 
 import javax.validation.constraints.NotEmpty;
 
 public class AdminRequest {
+    private static final AES256 AES256 = new AES256();
 
     @Getter
     @Setter
@@ -64,6 +67,23 @@ public class AdminRequest {
             this.orderType = OrderType.valueOf(orderType.toUpperCase());
             this.year = year;
             this.month = month;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class UserSearchDTO {
+        String empName;
+        String empNo;
+
+        public UserSearchDTO(String empName, String empNo) {
+            try {
+                this.empName = (empName == null) ? empName : AES256.encrypt(empName);
+            } catch (Exception e) {
+                throw new Exception500("서버 오류!");
+            }
+
+            this.empNo = empNo;
         }
     }
 }

--- a/src/main/java/fast/mini/be/domain/admin/AdminResponse.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminResponse.java
@@ -52,7 +52,7 @@ public class AdminResponse {
     }
 
     @Getter
-    public static class MonthCountDTO{
+    public static class MonthCountDTO {
         Long jan;
         Long feb;
         Long mar;
@@ -115,7 +115,7 @@ public class AdminResponse {
         MonthCountDTO month;
         Long total;
 
-        public MonthlyUserTotalDTO(User user,MonthCountDTO monthCountDTO) {
+        public MonthlyUserTotalDTO(User user, MonthCountDTO monthCountDTO) {
             this.id = user.getId();
             try {
                 this.empName = AES256.decrypt(user.getEmpName());
@@ -123,7 +123,7 @@ public class AdminResponse {
                 throw new Exception500("서버 오류!");
             }
             this.empNo = user.getEmpNo();
-            this.month =monthCountDTO;
+            this.month = monthCountDTO;
             this.total = monthCountDTO.getTotalCount();
         }
     }
@@ -148,6 +148,21 @@ public class AdminResponse {
 
         public static List<DailyOrderDTO> fromEntityList(List<ApproveDate> approveDateList) {
             return approveDateList.stream().map(DailyOrderDTO::new).collect(Collectors.toList());
+        }
+    }
+
+    @Getter
+    public static class UserSearchDTO {
+        Long id;
+        String empNo;
+        String empName;
+        String createdAt;
+
+        public UserSearchDTO(User user) {
+            this.id = user.getId();
+            this.empNo = user.getEmpNo();
+            this.empName = user.getEmpName();
+            this.createdAt = DateUtils.toStringFormat(user.getCreatedAt());
         }
     }
 }

--- a/src/main/java/fast/mini/be/domain/admin/AdminResponse.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminResponse.java
@@ -111,7 +111,7 @@ public class AdminResponse {
     public static class MonthlyUserTotalDTO {
         Long id;
         String empName;
-        String empNo;
+        Long empNo;
         MonthCountDTO month;
         Long total;
 
@@ -122,7 +122,7 @@ public class AdminResponse {
             } catch (Exception e) {
                 throw new Exception500("서버 오류!");
             }
-            this.empNo = user.getEmpNo();
+            this.empNo = Long.valueOf(user.getEmpNo());
             this.month = monthCountDTO;
             this.total = monthCountDTO.getTotalCount();
         }
@@ -131,7 +131,7 @@ public class AdminResponse {
     @Getter
     public static class DailyOrderDTO {
         String empName;
-        String empNo;
+        Long empNo;
         String orderType;
         String date;
 
@@ -141,7 +141,7 @@ public class AdminResponse {
             } catch (Exception e) {
                 throw new Exception500("서버 오류!");
             }
-            this.empNo = approveDate.getUser().getEmpNo();
+            this.empNo = Long.valueOf(approveDate.getUser().getEmpNo());
             this.orderType = approveDate.getOrder().getOrderType().getLabel();
             this.date = DateUtils.toStringFormat(approveDate.getDate());
         }
@@ -154,13 +154,13 @@ public class AdminResponse {
     @Getter
     public static class UserSearchDTO {
         Long id;
-        String empNo;
+        Long empNo;
         String empName;
         String createdAt;
 
         public UserSearchDTO(User user) {
             this.id = user.getId();
-            this.empNo = user.getEmpNo();
+            this.empNo = Long.valueOf(user.getEmpNo());
             try {
                 this.empName = AES256.decrypt(user.getEmpName());
             } catch (Exception e) {

--- a/src/main/java/fast/mini/be/domain/admin/AdminResponse.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminResponse.java
@@ -169,4 +169,39 @@ public class AdminResponse {
             this.createdAt = DateUtils.toStringFormat(user.getCreatedAt());
         }
     }
+
+    @Getter
+    public static class OrderByUserIdDTO {
+        Long id;
+        String empName;
+        String createdAt;
+        String orderType;
+        String status;
+        String startDate;
+        String endDate;
+        String reason;
+        String category;
+        String etc;
+
+        private OrderByUserIdDTO(Order order) {
+            this.id = order.getId();
+            try {
+                this.empName = AES256.decrypt(order.getUser().getEmpName());
+            } catch (Exception e) {
+                throw new Exception500("서버 오류!");
+            }
+            this.createdAt = DateUtils.toStringFormat(order.getCreatedAt());
+            this.orderType = order.getOrderType().getLabel();
+            this.status = order.getStatus().getLabel();
+            this.startDate = DateUtils.toStringFormat(order.getStartDate());
+            this.endDate = DateUtils.toStringFormat(order.getEndDate());
+            this.reason = order.getReason();
+            this.category = order.getCategory();
+            this.etc = order.getEtc();
+        }
+
+        public static Page<OrderByUserIdDTO> fromEntityList(Page<Order> orderList) {
+            return orderList.map(OrderByUserIdDTO::new);
+        }
+    }
 }

--- a/src/main/java/fast/mini/be/domain/admin/AdminResponse.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminResponse.java
@@ -161,7 +161,11 @@ public class AdminResponse {
         public UserSearchDTO(User user) {
             this.id = user.getId();
             this.empNo = user.getEmpNo();
-            this.empName = user.getEmpName();
+            try {
+                this.empName = AES256.decrypt(user.getEmpName());
+            } catch (Exception e) {
+                throw new Exception500("서버 오류!");
+            }
             this.createdAt = DateUtils.toStringFormat(user.getCreatedAt());
         }
     }

--- a/src/main/java/fast/mini/be/domain/admin/AdminService.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminService.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -94,9 +93,10 @@ public class AdminService {
         return AdminResponse.DailyOrderDTO.fromEntityList(approveDateList);
     }
 
-    public AdminResponse.UserSearchDTO userSearch(String name, String empNo) {
-        User user = userRepository.findByEmpNameAndEmpNo(name, empNo)
+    public AdminResponse.UserSearchDTO userSearch(AdminRequest.UserSearchDTO userSearchDTO) {
+        User user = userRepository.findByEmpNameOrEmpNo(userSearchDTO.getEmpName(), userSearchDTO.getEmpNo())
                 .orElseThrow(() -> new Exception404("해당유저가 존재하지 않습니다."));
+
         return new AdminResponse.UserSearchDTO(user);
     }
 }

--- a/src/main/java/fast/mini/be/domain/admin/AdminService.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminService.java
@@ -99,4 +99,11 @@ public class AdminService {
 
         return new AdminResponse.UserSearchDTO(user);
     }
+
+    public Page<AdminResponse.OrderByUserIdDTO> orderListByUserId(long userId, Pageable pageable) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new Exception404("해당유저가 존재하지 않습니다."));
+        Page<Order> orderList = orderRepository.findAllByUserId(user.getId(), pageable);
+
+        return AdminResponse.OrderByUserIdDTO.fromEntityList(orderList);
+    }
 }

--- a/src/main/java/fast/mini/be/domain/admin/AdminService.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminService.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -46,42 +47,44 @@ public class AdminService {
             }
         }
     }
-  
-    public Page<AdminResponse.OrderByStatusDTO> orderListByStatus(String status, Pageable pageable){
+
+    public Page<AdminResponse.OrderByStatusDTO> orderListByStatus(String status, Pageable pageable) {
         Page<Order> orderList;
-        if(OrderStatus.WAIT.name().equals(status.toUpperCase())){
-            orderList= orderRepository.findAllByStatus(OrderStatus.WAIT, pageable);
-        }else{
-            orderList= orderRepository.findAllByStatusNot(OrderStatus.WAIT, pageable);
+        if (OrderStatus.WAIT.name().equals(status.toUpperCase())) {
+            orderList = orderRepository.findAllByStatus(OrderStatus.WAIT, pageable);
+        } else {
+            orderList = orderRepository.findAllByStatusNot(OrderStatus.WAIT, pageable);
         }
 
         return AdminResponse.OrderByStatusDTO.fromEntityList(orderList);
     }
 
-    public List<AdminResponse.MonthlyUserTotalDTO> monthlyUserTotal(AdminRequest.MonthlyUserTotalDTO monthlyUserTotalDTO){
+    public List<AdminResponse.MonthlyUserTotalDTO> monthlyUserTotal(AdminRequest.MonthlyUserTotalDTO monthlyUserTotalDTO) {
         // 모든 사원에 대한 사용 대장을 구한다
         List<User> users = userRepository.findAllByRole(Role.USER)
-                .orElseThrow(()->{return new Exception404("사용자를 찾을 수 없습니다.");});
+                .orElseThrow(() -> {
+                    return new Exception404("사용자를 찾을 수 없습니다.");
+                });
 
         List<AdminResponse.MonthlyUserTotalDTO> monthlyUserTotalDTOList = new ArrayList<>();
-        for(User user : users){
+        for (User user : users) {
             // 0으로 초기화된 월별 카운트 DTO
             AdminResponse.MonthCountDTO monthCountDTO = new AdminResponse.MonthCountDTO();
 
             // 해당 사원이 승인된 요청을 가지는지 찾고 월별 카운트를 갱신한다
             Optional<List<ApproveDate>> approveDateList = approveDateRepository.findAllByUserAndOrderTypeInYear(
-                            user.getId(), monthlyUserTotalDTO.getOrderType(), monthlyUserTotalDTO.getYear()
+                    user.getId(), monthlyUserTotalDTO.getOrderType(), monthlyUserTotalDTO.getYear()
             );
             approveDateList.ifPresent(monthCountDTO::count);
 
             // 해당 사원의 사용 대장을 추가한다
-            monthlyUserTotalDTOList.add(new AdminResponse.MonthlyUserTotalDTO(user,monthCountDTO));
+            monthlyUserTotalDTOList.add(new AdminResponse.MonthlyUserTotalDTO(user, monthCountDTO));
         }
 
         return monthlyUserTotalDTOList;
     }
 
-    public List<AdminResponse.DailyOrderDTO> dailyOrderList(AdminRequest.DailyOrderListDTO dailyOrderListDTO){
+    public List<AdminResponse.DailyOrderDTO> dailyOrderList(AdminRequest.DailyOrderListDTO dailyOrderListDTO) {
         List<ApproveDate> approveDateList = approveDateRepository
                 .findAllByOrderTypeInYearMonth(
                         dailyOrderListDTO.getOrderType(), dailyOrderListDTO.getYear(), dailyOrderListDTO.getMonth()
@@ -89,5 +92,11 @@ public class AdminService {
                 .orElseThrow(() -> new Exception404("해당 데이터가 존재하지 않습니다."));
 
         return AdminResponse.DailyOrderDTO.fromEntityList(approveDateList);
+    }
+
+    public AdminResponse.UserSearchDTO userSearch(String name, String empNo) {
+        User user = userRepository.findByEmpNameAndEmpNo(name, empNo)
+                .orElseThrow(() -> new Exception404("해당유저가 존재하지 않습니다."));
+        return new AdminResponse.UserSearchDTO(user);
     }
 }

--- a/src/main/java/fast/mini/be/domain/admin/AdminTokenValidationAspect.java
+++ b/src/main/java/fast/mini/be/domain/admin/AdminTokenValidationAspect.java
@@ -1,0 +1,21 @@
+package fast.mini.be.domain.admin;
+
+import fast.mini.be.global.erros.exception.Exception401;
+import fast.mini.be.global.jwt.service.JwtService;
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Aspect
+@Component
+public class AdminTokenValidationAspect {
+    private final JwtService jwtService;
+
+    @Before("execution(* fast.mini.be.domain.admin.AdminController.*(..)) && args(token,..)")
+    public void validateToken(String token) throws Exception401 {
+        String jwtToken = token.replace("Bearer ", "");
+        jwtService.extractUsername(jwtToken).orElseThrow(() -> new Exception401("유효하지 않은 토큰입니다"));
+    }
+}

--- a/src/main/java/fast/mini/be/domain/order/OrderRepository.java
+++ b/src/main/java/fast/mini/be/domain/order/OrderRepository.java
@@ -5,15 +5,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OrderRepository extends JpaRepository<Order,Long> {
-	List<Order> findByUserEmail(String email);
+public interface OrderRepository extends JpaRepository<Order, Long> {
+    List<Order> findByUserEmail(String email);
 
-	Page<Order> findByUserEmail(String email, Pageable pageable);
-  
+    Page<Order> findByUserEmail(String email, Pageable pageable);
+
     Page<Order> findAllByStatus(OrderStatus status, Pageable pageable);
 
     Page<Order> findAllByStatusNot(OrderStatus status, Pageable pageable);
 
+    Page<Order> findAllByUserId(long userId, Pageable pageable);
 }

--- a/src/main/java/fast/mini/be/domain/user/repository/UserRepository.java
+++ b/src/main/java/fast/mini/be/domain/user/repository/UserRepository.java
@@ -18,5 +18,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<List<User>> findAllByRole(Role role);
 
-    Optional<User> findByEmpNameAndEmpNo(@RequestParam(required = false) String empName, @RequestParam(required = false) String empNo);
+    Optional<User> findByEmpNameOrEmpNo(@RequestParam(required = false) String empName, @RequestParam(required = false) String empNo);
 }

--- a/src/main/java/fast/mini/be/domain/user/repository/UserRepository.java
+++ b/src/main/java/fast/mini/be/domain/user/repository/UserRepository.java
@@ -3,6 +3,7 @@ package fast.mini.be.domain.user.repository;
 import fast.mini.be.domain.user.Role;
 import fast.mini.be.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,4 +17,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByRefreshToken(String refreshToken);
 
     Optional<List<User>> findAllByRole(Role role);
+
+    Optional<User> findByEmpNameAndEmpNo(@RequestParam(required = false) String empName, @RequestParam(required = false) String empNo);
 }

--- a/src/main/java/fast/mini/be/domain/user/repository/UserRepository.java
+++ b/src/main/java/fast/mini/be/domain/user/repository/UserRepository.java
@@ -19,4 +19,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<List<User>> findAllByRole(Role role);
 
     Optional<User> findByEmpNameOrEmpNo(@RequestParam(required = false) String empName, @RequestParam(required = false) String empNo);
+
+    Optional<User> findById(long userId);
 }

--- a/src/main/java/fast/mini/be/global/config/SecurityConfig.java
+++ b/src/main/java/fast/mini/be/global/config/SecurityConfig.java
@@ -33,21 +33,25 @@ public class SecurityConfig {
     @Bean
 //    public SecurityFilterChain filterChain(HttpSecurity http, Jwt jwt, TokenService tokenService) throws
     public SecurityFilterChain filterChain(HttpSecurity http) throws
-        Exception {
+            Exception {
         http
-            .formLogin().disable()//1 - formLogin 인증방법 비활성화
-            .httpBasic().disable()//2 - httpBasic 인증방법 비활성화(특정 리소스에 접근할 때 username과 password 물어봄)
-            .csrf().disable()
-            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .formLogin().disable()//1 - formLogin 인증방법 비활성화
+                .httpBasic().disable()//2 - httpBasic 인증방법 비활성화(특정 리소스에 접근할 때 username과 password 물어봄)
+                .csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 
-            .and()
-            .authorizeRequests()
-            .antMatchers("/api/login", "/api/register").permitAll()
-            .anyRequest().authenticated();
+                .and()
+                .authorizeRequests()
+                .antMatchers("/api/login", "/api/register").permitAll()
+                .antMatchers("/api/user/**")
+                .access("hasRole('ADMIN') or hasRole('USER')")
+                .antMatchers("/api/admin/**")
+                .access("hasRole('ADMIN')")
+                .anyRequest().authenticated();
 
         http.addFilterAfter(jsonEmailPasswordLoginFilter(), LogoutFilter.class);
         http.addFilterBefore(jwtAuthenticationProcessingFilter(),
-            JsonEmailPasswordAuthenticationFilter.class);
+                JsonEmailPasswordAuthenticationFilter.class);
 
 //            .and()
 //            .addFilterBefore(jwtAuthenticationFilter(jwt, tokenService), UsernamePasswordAuthenticationFilter.class)
@@ -83,10 +87,10 @@ public class SecurityConfig {
     @Bean
     public JsonEmailPasswordAuthenticationFilter jsonEmailPasswordLoginFilter() {
         JsonEmailPasswordAuthenticationFilter jsonEmailPasswordLoginFilter = new JsonEmailPasswordAuthenticationFilter(
-            objectMapper);
+                objectMapper);
         jsonEmailPasswordLoginFilter.setAuthenticationManager(authenticationManager());
         jsonEmailPasswordLoginFilter.setAuthenticationSuccessHandler(
-            loginSuccessJWTProvideHandler());
+                loginSuccessJWTProvideHandler());
         jsonEmailPasswordLoginFilter.setAuthenticationFailureHandler(loginFailureHandler());
         return jsonEmailPasswordLoginFilter;
     }
@@ -95,7 +99,7 @@ public class SecurityConfig {
     @Bean
     public JwtAuthenticationProcessingFilter jwtAuthenticationProcessingFilter() {
         JwtAuthenticationProcessingFilter jsonUsernamePasswordLoginFilter = new JwtAuthenticationProcessingFilter(
-            jwtService, userRepository);
+                jwtService, userRepository);
 
         return jsonUsernamePasswordLoginFilter;
     }

--- a/src/main/java/fast/mini/be/global/utils/DBInit.java
+++ b/src/main/java/fast/mini/be/global/utils/DBInit.java
@@ -147,6 +147,17 @@ public class DBInit {
                 .build();
         user10.setCreatedAt(LocalDateTime.of(2021,10,29,10,18,32));
         userRepository.save(user10);
+
+        User admin = User.builder()
+                .email("admin@gmail.com")
+                .password(passwordEncoder.encode("admin1!"))
+                .empName(AES256.encrypt("어드민"))
+                .empNo("99999999")
+                .position("관리자")
+                .role(Role.ADMIN)
+                .annualCount(0)
+                .build();
+        userRepository.save(admin);
     }
 
     private void initOrder() {

--- a/src/test/java/fast/mini/be/domain/admin/AdminServiceTest.java
+++ b/src/test/java/fast/mini/be/domain/admin/AdminServiceTest.java
@@ -299,4 +299,37 @@ class AdminServiceTest {
             adminService.userSearch(requestDTO);
         });
     }
+
+    @Test
+    public void ok_orderListByUserId() {
+        // given
+        Long userId = 1L;
+        Pageable pageable = (Pageable) PageRequest.of(0, 4);
+
+        // when
+        Page<AdminResponse.OrderByUserIdDTO> orderListByUserIdDTO = adminService.orderListByUserId(userId, pageable);
+
+        // then
+        assertEquals(orderListByUserIdDTO.getNumber(), 0, "현재 페이지는 0번째이다");
+        assertEquals(orderListByUserIdDTO.getNumberOfElements(), 4, "한 페이지에 데이터는 4개이다.");
+
+        List<AdminResponse.OrderByUserIdDTO> content = orderListByUserIdDTO.getContent();
+        assertEquals(content.get(0).getEmpName(), "박지훈", "박지훈의 신청 내역");
+        assertEquals(content.get(1).getEmpName(), "박지훈", "박지훈의 신청 내역");
+        assertEquals(content.get(2).getEmpName(), "박지훈", "박지훈의 신청 내역");
+        assertEquals(content.get(3).getEmpName(), "박지훈", "박지훈의 신청 내역");
+    }
+
+    @Test
+    public void fail_orderListByUserId() {
+        // given
+        Long userId = 1000L; // 없는 유저
+        Pageable pageable = (Pageable) PageRequest.of(0, 4);
+
+        // when
+        // then
+        assertThrows(Exception404.class, () -> {
+            adminService.orderListByUserId(userId, pageable);
+        });
+    }
 }

--- a/src/test/java/fast/mini/be/domain/admin/AdminServiceTest.java
+++ b/src/test/java/fast/mini/be/domain/admin/AdminServiceTest.java
@@ -249,4 +249,54 @@ class AdminServiceTest {
                 o -> assertTrue(o.getDate().matches("^2023-08-(0[1-9]|[1-2][0-9]|3[0-1])$"))
         );
     }
+
+    @Test
+    public void ok_userSearch_name() {
+        // given
+        String name = "박지훈";
+        String empNo = null;
+        AdminRequest.UserSearchDTO requestDTO = new AdminRequest.UserSearchDTO(name, empNo);
+
+        // when
+        AdminResponse.UserSearchDTO userSearchDTO = adminService.userSearch(requestDTO);
+
+        // then
+        assertEquals(userSearchDTO.getId(), 1, "유저 아이디");
+        assertEquals(userSearchDTO.getEmpName(), "박지훈", "유저 이름");
+        assertEquals(userSearchDTO.getEmpNo(), "20200001", "유저 사원번호");
+        // 더미 데이터에 createdAt 지정한 값이 아닌 현재 시간이 들어가는 오류로 확인 불가
+//        assertEquals(userSearchDTO.getCreatedAt(), "2020-11-29", "유저 입사일");
+    }
+
+    @Test
+    public void ok_userSearch_empno() {
+        // given
+        String name = null;
+        String empNo = "20200001";
+        AdminRequest.UserSearchDTO requestDTO = new AdminRequest.UserSearchDTO(name, empNo);
+
+        // when
+        AdminResponse.UserSearchDTO userSearchDTO = adminService.userSearch(requestDTO);
+
+        // then
+        assertEquals(userSearchDTO.getId(), 1, "유저 아이디");
+        assertEquals(userSearchDTO.getEmpName(), "박지훈", "유저 이름");
+        assertEquals(userSearchDTO.getEmpNo(), "20200001", "유저 사원번호");
+        // 더미 데이터에 createdAt 지정한 값이 아닌 현재 시간이 들어가는 오류로 확인 불가
+//        assertEquals(userSearchDTO.getCreatedAt(), "2020-11-29", "유저 입사일");
+    }
+
+    @Test
+    public void fail_userSearch_empno() {
+        // given
+        String name = null;
+        String empNo = "11110001";
+        AdminRequest.UserSearchDTO requestDTO = new AdminRequest.UserSearchDTO(name, empNo);
+
+        // when
+        // then
+        assertThrows(Exception404.class, () -> {
+            adminService.userSearch(requestDTO);
+        });
+    }
 }


### PR DESCRIPTION
### API URL 
- /api/admin/user/search?name=홍길동
- /api/admin/user/search?empno=20230001
- /api/admin/order/list?user=1&page=1&size=5

### 구현 내용 
- 이름 또는 사원 번호로 사원 조회
- 조회한 사원의 id 값으로 연차/당직 사용 내역 조회

### 테스트
- [X] service (테스트 코드 작성)
- [X] controller (postman으로 직접 테스트)

### 특이사항
- 전체 Controller에서 미구현 상태였던 token 유효성 검사 모두 추가 완료
- 관리자 페이지 모두 구현 완료